### PR TITLE
Made MPI optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ ifeq ($(USE_PARALLEL_SORT),1)
   CPPFLAGS += -DUSE_PARALLEL_SORT 
 endif
 
+# --- Support for MPI --- #
+MPI =
+ifeq ($(MPI),1)
+  CPPFLAGS += -DHAVE_MPI
+endif
+
 # --- Compilers --- #
 CXX = g++   
 

--- a/core/include/c_api/c_api.h
+++ b/core/include/c_api/c_api.h
@@ -34,7 +34,9 @@
 #define __C_API_H__
 
 #include "constants.h"
-#include <mpi.h>
+#ifdef HAVE_MPI
+  #include <mpi.h>
+#endif
 #include <stdint.h>
 #include <stddef.h>
 #include <string>
@@ -91,8 +93,10 @@ typedef struct TileDB_Config {
    * default home directory will be used, which is ~/.tiledb/. 
    */
   const char* home_;
+#ifdef HAVE_MPI
   /** The MPI communicator. Use NULL if no MPI is used. */
   MPI_Comm* mpi_comm_; 
+#endif
   /** 
    * The method for reading data from a file. 
    * It can be one of the following: 

--- a/core/include/fragment/read_state.h
+++ b/core/include/fragment/read_state.h
@@ -686,6 +686,7 @@ class ReadState {
       off_t offset,
       size_t tile_size);
 
+#ifdef HAVE_MPI
   /** 
    * Reads a tile from the disk for an attribute into a local buffer, using 
    * MPI-IO. This function focuses on the case of GZIP compression.
@@ -714,6 +715,7 @@ class ReadState {
       int attribute_id,
       off_t offset,
       size_t tile_size);
+#endif
 
   /**
    * Prepares a tile from the disk for reading for an attribute.    

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -33,7 +33,9 @@
 #ifndef __UTILS_H__
 #define __UTILS_H__
 
-#include <mpi.h>
+#ifdef HAVE_MPI
+  #include <mpi.h>
+#endif
 #include <pthread.h>
 #include <string>
 #include <vector>
@@ -406,6 +408,7 @@ bool is_unary_subarray(const T* subarray, int dim_num);
  */
 bool is_workspace(const std::string& dir);
 
+#ifdef HAVE_MPI
 /**
  * Reads data from a file into a buffer using MPI-IO.
  *
@@ -448,6 +451,7 @@ int mpi_io_write_to_file(
     const char* filename,
     const void* buffer, 
     size_t buffer_size);
+#endif
 
 #ifdef HAVE_OPENMP
 /**

--- a/core/include/storage_manager/config.h
+++ b/core/include/storage_manager/config.h
@@ -33,7 +33,9 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-#include <mpi.h>
+#ifdef HAVE_MPI
+  #include <mpi.h>
+#endif
 #include <string>
 
 
@@ -59,6 +61,7 @@ class Config {
   /*             MUTATORS              */
   /* ********************************* */
 
+#ifdef HAVE_MPI
   /**
    * Initializes the configuration parameters.
    *
@@ -66,17 +69,17 @@ class Config {
    * @param mpi_comm The MPI communicator.
    * @param read_method The method for reading data from a file. 
    *     It can be one of the following: 
-   *        - TILEDB_USE_READ
+   *        - TILEDB_IO_READ
    *          TileDB will use POSIX read.
-   *        - TILEDB_USE_MMAP
+   *        - TILEDB_IO_MMAP
    *          TileDB will use mmap.
-   *        - TILEDB_USE_MPIIO
+   *        - TILEDB_IO_MPI
    *          TileDB will use MPI-IO read. 
    * @param write_method The method for writing data to a file. 
    *     It can be one of the following: 
-   *        - TILEDB_USE_WRITE
+   *        - TILEDB_IO_WRITE
    *          TileDB will use POSIX write.
-   *        - TILEDB_USE_MPI_IO
+   *        - TILEDB_IO_MPI
    *          TileDB will use MPI-IO write.
    * @return void. 
    */
@@ -85,7 +88,32 @@ class Config {
       MPI_Comm* mpi_comm,
       int read_method,
       int write_methods); 
-
+#else
+  /**
+   * Initializes the configuration parameters.
+   *
+   * @param home The TileDB home directory.
+   * @param read_method The method for reading data from a file. 
+   *     It can be one of the following: 
+   *        - TILEDB_IO_READ
+   *          TileDB will use POSIX read.
+   *        - TILEDB_IO_MMAP
+   *          TileDB will use mmap.
+   *        - TILEDB_IO_MPI
+   *          TileDB will use MPI-IO read. 
+   * @param write_method The method for writing data to a file. 
+   *     It can be one of the following: 
+   *        - TILEDB_IO_WRITE
+   *          TileDB will use POSIX write.
+   *        - TILEDB_IO_MPI
+   *          TileDB will use MPI-IO write.
+   * @return void. 
+   */
+  void init(
+      const char* home,
+      int read_method,
+      int write_methods);
+#endif
  
   /* ********************************* */
   /*             ACCESSORS             */
@@ -94,8 +122,10 @@ class Config {
   /** Returns the TileDB home directory. */
   const std::string& home() const; 
 
+#ifdef HAVE_MPI
   /** Returns the MPI communicator. */
   MPI_Comm* mpi_comm() const;
+#endif
 
   /** Returns the read method. */
   int read_method() const;
@@ -110,25 +140,27 @@ class Config {
 
   /** TileDB home directory. */
   std::string home_;
+#ifdef HAVE_MPI
   /** The MPI communicator. */
   MPI_Comm* mpi_comm_;
+#endif
   /** 
    * The method for reading data from a file. 
    * It can be one of the following: 
-   *    - TILEDB_USE_READ
+   *    - TILEDB_IO_READ
    *      TileDB will use POSIX read.
-   *    - TILEDB_USE_MMAP
+   *    - TILEDB_IO_MMAP
    *      TileDB will use mmap.
-   *    - TILEDB_USE_MPI_IO
+   *    - TILEDB_IO_MPI
    *      TileDB will use MPI-IO read. 
    */
   int read_method_;
   /** 
    * The method for writing data to a file. 
    * It can be one of the following: 
-   *    - TILEDB_USE_WRITE
+   *    - TILEDB_IO_WRITE
    *      TileDB will use POSIX write.
-   *    - TILEDB_USE_MPI_IO
+   *    - TILEDB_IO_MPI
    *      TileDB will use MPI-IO write. 
    */
   int write_method_;

--- a/core/src/c_api/c_api.cc
+++ b/core/src/c_api/c_api.cc
@@ -91,7 +91,9 @@ int tiledb_ctx_init(
   if(tiledb_config != NULL)
     config->init(
         tiledb_config->home_, 
+#ifdef HAVE_MPI
         tiledb_config->mpi_comm_, 
+#endif
         tiledb_config->read_method_, 
         tiledb_config->write_method_);
 

--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -192,7 +192,9 @@ int WriteState::sync() {
   const ArraySchema* array_schema = fragment_->array()->array_schema();
   const std::vector<int>& attribute_ids = fragment_->array()->attribute_ids();
   int write_method = fragment_->array()->config()->write_method();
+#ifdef HAVE_MPI
   MPI_Comm* mpi_comm = fragment_->array()->config()->mpi_comm();
+#endif
   std::string filename;
   int rc;
 
@@ -202,12 +204,21 @@ int WriteState::sync() {
     filename = 
         fragment_->fragment_name() + "/" + 
         array_schema->attribute(attribute_ids[i]) + TILEDB_FILE_SUFFIX;
-    if(write_method == TILEDB_IO_WRITE)
+    if(write_method == TILEDB_IO_WRITE) {
       rc = ::sync(filename.c_str());
-    else if(write_method == TILEDB_IO_MPI) 
+    } else if(write_method == TILEDB_IO_MPI) { 
+#ifdef HAVE_MPI
       rc = mpi_io_sync(mpi_comm, filename.c_str());
-    else
+#else
+    // Error: MPI not supported
+    std::string errmsg = "Cannot sync; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+    } else {
       assert(0);
+    }
 
     // Handle error
     if(rc != TILEDB_UT_OK) {
@@ -221,12 +232,21 @@ int WriteState::sync() {
           fragment_->fragment_name() + "/" + 
           array_schema->attribute(attribute_ids[i]) + "_var" + 
           TILEDB_FILE_SUFFIX;
-      if(write_method == TILEDB_IO_WRITE)
+      if(write_method == TILEDB_IO_WRITE) {
         rc = ::sync(filename.c_str());
-      else if(write_method == TILEDB_IO_MPI) 
+      } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
         rc = mpi_io_sync(mpi_comm, filename.c_str());
-      else
+#else
+    // Error: MPI not supported
+    std::string errmsg = "Cannot sync; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+      } else {
         assert(0);
+      }
     }
 
     // Handle error
@@ -238,12 +258,21 @@ int WriteState::sync() {
 
   // Sync fragment directory
   filename = fragment_->fragment_name();
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
     rc = ::sync(filename.c_str());
-  else if(write_method == TILEDB_IO_MPI) 
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
     rc = mpi_io_sync(mpi_comm, filename.c_str());
-  else
+#else
+    // Error: MPI not supported
+    std::string errmsg = "Cannot sync; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  } else {
     assert(0);
+  }
 
   // Handle error
   if(rc != TILEDB_UT_OK) {
@@ -259,19 +288,30 @@ int WriteState::sync_attribute(const std::string& attribute) {
   // For easy reference
   const ArraySchema* array_schema = fragment_->array()->array_schema();
   int write_method = fragment_->array()->config()->write_method();
+#ifdef HAVE_MPI
   MPI_Comm* mpi_comm = fragment_->array()->config()->mpi_comm();
+#endif
   int attribute_id = array_schema->attribute_id(attribute); 
   std::string filename;
   int rc;
 
   // Sync attribute
   filename = fragment_->fragment_name() + "/" + attribute + TILEDB_FILE_SUFFIX;
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
     rc = ::sync(filename.c_str());
-  else if(write_method == TILEDB_IO_MPI) 
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
     rc = mpi_io_sync(mpi_comm, filename.c_str());
-  else
+#else
+    // Error: MPI not supported
+    std::string errmsg = "Cannot sync attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  } else {
     assert(0);
+  }
 
   // Handle error
   if(rc != TILEDB_UT_OK) {
@@ -284,12 +324,21 @@ int WriteState::sync_attribute(const std::string& attribute) {
     filename = 
         fragment_->fragment_name() + "/" + 
         attribute + "_var" + TILEDB_FILE_SUFFIX;
-    if(write_method == TILEDB_IO_WRITE)
+    if(write_method == TILEDB_IO_WRITE) {
       rc = ::sync(filename.c_str());
-    else if(write_method == TILEDB_IO_MPI) 
+    } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_sync(mpi_comm, filename.c_str());
-    else
+#else
+    // Error: MPI not supported
+    std::string errmsg = "Cannot sync attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+    } else {
       assert(0);
+    }
   }
 
   // Handle error
@@ -300,12 +349,21 @@ int WriteState::sync_attribute(const std::string& attribute) {
 
   // Sync fragment directory
   filename = fragment_->fragment_name();
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
     rc = ::sync(filename.c_str());
-  else if(write_method == TILEDB_IO_MPI) 
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
     rc = mpi_io_sync(mpi_comm, filename.c_str());
-  else
+#else
+    // Error: MPI not supported
+    std::string errmsg = "Cannot sync attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  } else {
     assert(0);
+  }
 
   // Handle error
   if(rc != TILEDB_UT_OK) {
@@ -423,17 +481,26 @@ int WriteState::compress_and_write_tile(int attribute_id) {
   // Write segment to file
   int rc = TILEDB_UT_OK;
   int write_method = fragment_->array()->config()->write_method();
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                tile_compressed_,
                tile_compressed_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                fragment_->array()->config()->mpi_comm(),
                filename.c_str(),
                tile_compressed_,
                tile_compressed_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = "Cannot compress and write tile; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Error
   if(rc != TILEDB_UT_OK) {
@@ -498,17 +565,27 @@ int WriteState::compress_and_write_tile_var(int attribute_id) {
   // Write segment to file
   int rc = TILEDB_UT_OK;
   int write_method = fragment_->array()->config()->write_method();
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                tile_compressed_,
                tile_compressed_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                fragment_->array()->config()->mpi_comm(),
                filename.c_str(),
                tile_compressed_,
                tile_compressed_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = 
+        "Cannot compress and write variable tile; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Error
   if(rc != TILEDB_UT_OK) {
@@ -811,17 +888,27 @@ int WriteState::write_dense_attr_cmp_none(
       TILEDB_FILE_SUFFIX;
   int rc = TILEDB_UT_OK;
   int write_method = fragment_->array()->config()->write_method();
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                buffer,
                buffer_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                fragment_->array()->config()->mpi_comm(),
                filename.c_str(),
                buffer,
                buffer_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = 
+        "Cannot write dense attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Error
   if(rc != TILEDB_UT_OK) {
@@ -945,18 +1032,30 @@ int WriteState::write_dense_attr_var_cmp_none(
       TILEDB_FILE_SUFFIX;
   int rc = TILEDB_UT_OK;
   int write_method = fragment_->array()->config()->write_method();
+#ifdef HAVE_MPI
   MPI_Comm* mpi_comm = fragment_->array()->config()->mpi_comm();
-  if(write_method == TILEDB_IO_WRITE)
+#endif
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                buffer_var,
                buffer_var_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                mpi_comm,
                filename.c_str(),
                buffer_var,
                buffer_var_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = 
+        "Cannot write dense variable attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Error
   if(rc != TILEDB_UT_OK) {
@@ -977,17 +1076,27 @@ int WriteState::write_dense_attr_var_cmp_none(
   filename = fragment_->fragment_name() + "/" + 
       array_schema->attribute(attribute_id) + 
       TILEDB_FILE_SUFFIX;
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                shifted_buffer,
                buffer_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                mpi_comm,
                filename.c_str(),
                shifted_buffer,
                buffer_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = 
+        "Cannot write dense variable attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Clean up
   free(shifted_buffer);
@@ -1261,18 +1370,30 @@ int WriteState::write_sparse_attr_cmp_none(
       TILEDB_FILE_SUFFIX;
   int rc = TILEDB_UT_OK;
   int write_method = fragment_->array()->config()->write_method();
+#ifdef HAVE_MPI
   MPI_Comm* mpi_comm = fragment_->array()->config()->mpi_comm();
-  if(write_method == TILEDB_IO_WRITE)
+#endif
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                buffer,
                buffer_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                mpi_comm,
                filename.c_str(),
                buffer,
                buffer_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = 
+        "Cannot write sparse attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Error
   if(rc != TILEDB_UT_OK) {
@@ -1405,18 +1526,30 @@ int WriteState::write_sparse_attr_var_cmp_none(
       TILEDB_FILE_SUFFIX;
   int rc = TILEDB_UT_OK;
   int write_method = fragment_->array()->config()->write_method();
+#ifdef HAVE_MPI
   MPI_Comm* mpi_comm = fragment_->array()->config()->mpi_comm();
-  if(write_method == TILEDB_IO_WRITE)
+#endif
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                buffer_var,
                buffer_var_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                mpi_comm,
                filename.c_str(),
                buffer_var,
                buffer_var_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = 
+        "Cannot write sparse variable attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Error
   if(rc != TILEDB_UT_OK) {
@@ -1437,17 +1570,27 @@ int WriteState::write_sparse_attr_var_cmp_none(
   filename = fragment_->fragment_name() + "/" + 
       array_schema->attribute(attribute_id) + 
       TILEDB_FILE_SUFFIX;
-  if(write_method == TILEDB_IO_WRITE)
+  if(write_method == TILEDB_IO_WRITE) {
       rc = write_to_file(
                filename.c_str(),
                shifted_buffer,
                buffer_size);
-  else if(write_method == TILEDB_IO_MPI)
+  } else if(write_method == TILEDB_IO_MPI) {
+#ifdef HAVE_MPI
       rc = mpi_io_write_to_file(
                mpi_comm,
                filename.c_str(),
                shifted_buffer,
                buffer_size);
+#else
+    // Error: MPI not supported
+    std::string errmsg = 
+        "Cannot write sparse variable attribute; MPI not supported";
+    PRINT_ERROR(errmsg);
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    return TILEDB_WS_ERR;
+#endif
+  }
 
   // Clean up
   free(shifted_buffer);

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -635,6 +635,7 @@ bool is_workspace(const std::string& dir) {
     return false;
 }
 
+#ifdef HAVE_MPI
 int mpi_io_read_from_file(
     const MPI_Comm* mpi_comm,
     const std::string& filename,
@@ -804,6 +805,7 @@ int mpi_io_sync(
   // Success 
   return TILEDB_UT_OK;
 }
+#endif
 
 #ifdef HAVE_OPENMP
 int mutex_destroy(omp_lock_t* mtx) {

--- a/core/src/storage_manager/config.cc
+++ b/core/src/storage_manager/config.cc
@@ -47,7 +47,9 @@ Config::Config() {
   home_ = "";
   read_method_ = TILEDB_IO_MMAP;
   write_method_ = TILEDB_IO_WRITE;
+#ifdef HAVE_MPI
   mpi_comm_ = NULL;
+#endif
 }
 
 Config::~Config() {
@@ -62,7 +64,9 @@ Config::~Config() {
 
 void Config::init(
     const char* home,
+#ifdef HAVE_MPI
     MPI_Comm* mpi_comm,
+#endif
     int read_method,
     int write_method) {
   // Initialize home
@@ -71,8 +75,10 @@ void Config::init(
   else
     home_ = home;
 
+#ifdef HAVE_MPI
   // Initialize MPI communicator
   mpi_comm_ = mpi_comm;
+#endif
 
   // Initialize read method
   read_method_ = read_method;
@@ -99,9 +105,11 @@ const std::string& Config::home() const {
   return home_;
 }
 
+#ifdef HAVE_MPI
 MPI_Comm* Config::mpi_comm() const {
   return mpi_comm_;
 }
+#endif
 
 int Config::read_method() const {
   return read_method_;

--- a/examples/src/tiledb_array_parallel_read_dense_2.cc
+++ b/examples/src/tiledb_array_parallel_read_dense_2.cc
@@ -164,7 +164,7 @@ void parallel_read(
 #else
 
 int main() {
-  printf("OpenMP not supported.");
+  printf("OpenMP not supported.\n");
 
   return 0;
 }

--- a/examples/src/tiledb_array_parallel_read_mpi_io_dense.cc
+++ b/examples/src/tiledb_array_parallel_read_mpi_io_dense.cc
@@ -34,12 +34,13 @@
  */
 
 #include "c_api.h"
-#include <mpi.h>
 #include <stdio.h>
 #include <cstring>
 
 
 
+#ifdef HAVE_MPI
+#include <mpi.h>
 
 int main(int argc, char** argv) {
   // Initialize MPI and get rank
@@ -124,3 +125,12 @@ int main(int argc, char** argv) {
   return 0;
 }
 
+#else
+
+int main() {
+  printf("MPI not supported.");
+
+  return 0;
+}
+
+#endif

--- a/examples/src/tiledb_array_parallel_read_mpi_io_dense.cc
+++ b/examples/src/tiledb_array_parallel_read_mpi_io_dense.cc
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
 #else
 
 int main() {
-  printf("MPI not supported.");
+  printf("MPI not supported.\n");
 
   return 0;
 }


### PR DESCRIPTION
MPI is now optional upon building TileDB, which is enabled by setting MPI=1 (default is 0) in make.
